### PR TITLE
Fixed issue #13

### DIFF
--- a/canvas.fs
+++ b/canvas.fs
@@ -147,12 +147,11 @@ let runApp (t:string) (w:int) (h:int)
     SDL.SDL_CreateWindowAndRenderer(viewWidth, viewHeight, windowFlags, &window, &renderer) |> ignore
     SDL.SDL_SetWindowTitle(window, t) |> ignore
     
-    //Our buffer and texture size is dependent on the first frame. 
     let firstFrame = draw w h (!state)
 
     let texture = SDL.SDL_CreateTexture(renderer, SDL.SDL_PIXELFORMAT_RGBA32, SDL.SDL_TEXTUREACCESS_STREAMING, firstFrame.w, firstFrame.h)
-    let frameBuffer = Array.create (firstFrame.w * firstFrame.h * 4) (byte(0))
     
+    let frameBuffer = Array.create (firstFrame.w * firstFrame.h * 4) (byte(0))
     let bufferPtr = IntPtr ((Marshal.UnsafeAddrOfPinnedArrayElement (frameBuffer, 0)).ToPointer ())
     let mutable keyEvent = SDL.SDL_KeyboardEvent 0u
 


### PR DESCRIPTION
## Bug description
- 1. Application crashes if you try to draw a frame larger than the canvas's window size. 
- 2. SDL not rendering a picture correctly if the ``viewWidth`` is not the same as the frame's width. 

## Cause
- 1. The ``frameBuffer`` is calculated as ``viewWidth * viewHeight *4``. It is possible to draw a frame larger than the view size. This means we can get frames containing more bytes than our buffer can store. This results in an overflow.
- 2. The ``SDL.SDL_UpdateTexture`` method requires a pitch. This pitch is calculated as ``viewWidth * 4``. It is possible to render a frame larger (or smaller) than the ``viewWidth``, and thus the pitch is not correct. This causing the rendering artifacts.  

## Solution
Instead of defining our buffer from the view size, we can calculate the first initial frame and use it's values for our buffersize calculations. This ensures (assuming the subsequent frames wont increase in size) an overflow will not happen. 
Likewise, we will define our texture from our frame's size. This will also allow us to correctly calculate the pitch our SDL renderer needs, regardless of our window size. This has one caveat that the image will now be stretched to fill the window's view.  

### Canvas window running the second script described in #13. It is noticeable stretched but is properly rendered.  
![image](https://user-images.githubusercontent.com/43752641/199383653-0637d747-54dc-4a5e-81fd-2100098f32a6.png)



## Limitations
- It is still possible to overflow the buffer if we construct a ``draw`` function that returns increasingly larger frames. 
- Images will be stretched to fill the window size.
- The first frame is calculated but not rendered. This means it takes two frames to load and draw the first frame. Every subsequent frame rendered is as expected. This could cause issues, if an application relies on one single calculation for the first frame to be rendered.