### PR TITLE
Add KeyUp event

### DIFF
--- a/SDL.fs
+++ b/SDL.fs
@@ -44,12 +44,6 @@ let SDLK_RIGHT = 1073741903u
 let SDLK_LEFT = 1073741904u
 let SDLK_DOWN = 1073741905u
 let SDLK_UP = 1073741906u
-// Define keymod for SDL
-// https://wiki.libsdl.org/SDL2/SDL_Keymod
-let KMOD_LSHIFT = 0001us
-let KMOD_RSHIFT = 0002us
-let KMOD_CAPS = 8192us
-let KMOD_NONE = 0000us
 
 let SDL_QUIT = 0x100u
 let SDL_USEREVENT = 0x8000u
@@ -67,6 +61,7 @@ type SDL_Keysym =
     end
 
 let SDL_SCANCODE_ESCAPE : int32 = 41
+let KMOD_NONE : uint16 = 0x0000us
 
 [<type:StructLayout(LayoutKind.Sequential)>]
 type SDL_KeyboardEvent =
@@ -84,30 +79,10 @@ type SDL_KeyboardEvent =
 [<DllImport(libName, CallingConvention = CallingConvention.Cdecl)>]
 extern IntPtr SDL_GetKeyName(uint32 key)
 
-[<DllImport(libName, CallingConvention = CallingConvention.Cdecl)>]
-extern uint16 SDL_GetModState()
-
 let stringFromKeyboard (kevent:SDL_KeyboardEvent) : string =
     let keyCode = kevent.keysym.sym
-    let keyNamePtr = SDL_GetKeyName keyCode
-    let keyName = Marshal.PtrToStringUTF8(keyNamePtr)
-
-    let modState = SDL_GetModState()
-    let leftShift = modState &&& KMOD_LSHIFT <> KMOD_NONE
-    let rightShift = modState &&& KMOD_RSHIFT <> KMOD_NONE
-    let caps = modState &&& KMOD_CAPS <> KMOD_NONE
-
-    if keyName.Length > 1 then // special keys
-        keyName
-    else
-        if caps && (leftShift || rightShift) then // caps and shift
-            keyName.ToLower()
-        elif (caps && not leftShift && not rightShift) 
-            || (not caps && leftShift && not rightShift) 
-            || (not caps && not leftShift && rightShift) then // caps or shift
-            keyName
-        else
-            keyName.ToLower()
+    let keyName = SDL_GetKeyName keyCode
+    Marshal.PtrToStringUTF8(keyName)
 
 let SDL_TEXTINPUTEVENT_TEXT_SIZE = 32
 

--- a/SDL.fs
+++ b/SDL.fs
@@ -44,6 +44,12 @@ let SDLK_RIGHT = 1073741903u
 let SDLK_LEFT = 1073741904u
 let SDLK_DOWN = 1073741905u
 let SDLK_UP = 1073741906u
+// Define keymod for SDL
+// https://wiki.libsdl.org/SDL2/SDL_Keymod
+let KMOD_LSHIFT = 0001us
+let KMOD_RSHIFT = 0002us
+let KMOD_CAPS = 8192us
+let KMOD_NONE = 0000us
 
 let SDL_QUIT = 0x100u
 let SDL_USEREVENT = 0x8000u
@@ -61,7 +67,6 @@ type SDL_Keysym =
     end
 
 let SDL_SCANCODE_ESCAPE : int32 = 41
-let KMOD_NONE : uint16 = 0x0000us
 
 [<type:StructLayout(LayoutKind.Sequential)>]
 type SDL_KeyboardEvent =
@@ -79,10 +84,30 @@ type SDL_KeyboardEvent =
 [<DllImport(libName, CallingConvention = CallingConvention.Cdecl)>]
 extern IntPtr SDL_GetKeyName(uint32 key)
 
+[<DllImport(libName, CallingConvention = CallingConvention.Cdecl)>]
+extern uint16 SDL_GetModState()
+
 let stringFromKeyboard (kevent:SDL_KeyboardEvent) : string =
     let keyCode = kevent.keysym.sym
-    let keyName = SDL_GetKeyName keyCode
-    Marshal.PtrToStringUTF8(keyName)
+    let keyNamePtr = SDL_GetKeyName keyCode
+    let keyName = Marshal.PtrToStringUTF8(keyNamePtr)
+
+    let modState = SDL_GetModState()
+    let leftShift = modState &&& KMOD_LSHIFT <> KMOD_NONE
+    let rightShift = modState &&& KMOD_RSHIFT <> KMOD_NONE
+    let caps = modState &&& KMOD_CAPS <> KMOD_NONE
+
+    if keyName.Length > 1 then // special keys
+        keyName
+    else
+        if caps && (leftShift || rightShift) then // caps and shift
+            keyName.ToLower()
+        elif (caps && not leftShift && not rightShift) 
+            || (not caps && leftShift && not rightShift) 
+            || (not caps && not leftShift && rightShift) then // caps or shift
+            keyName
+        else
+            keyName.ToLower()
 
 let SDL_TEXTINPUTEVENT_TEXT_SIZE = 32
 

--- a/SDL.fs
+++ b/SDL.fs
@@ -76,6 +76,13 @@ type SDL_KeyboardEvent =
         val keysym: SDL_Keysym
     end
 
+[<DllImport(libName, CallingConvention = CallingConvention.Cdecl)>]
+extern IntPtr SDL_GetKeyName(uint32 key)
+
+let stringFromKeyboard (kevent:SDL_KeyboardEvent) : string =
+    let keyCode = kevent.keysym.sym
+    let keyName = SDL_GetKeyName keyCode
+    Marshal.PtrToStringUTF8(keyName)
 
 let SDL_TEXTINPUTEVENT_TEXT_SIZE = 32
 
@@ -99,8 +106,6 @@ type SDL_TextInputEvent =
 let stringFromTextInput (tinput:SDL_TextInputEvent) : string =
     let addr = &&tinput.text.first
     Marshal.PtrToStringUTF8(NativePtr.toNativeInt addr)
-
-
 
 [<StructLayout(LayoutKind.Sequential)>]
 type SDL_UserEvent=

--- a/canvas.fs
+++ b/canvas.fs
@@ -22,6 +22,8 @@ let correct draw s = let (Picture pic) = draw s in pic
 type Event =
     /// A key with at letter is pressed
     | Key of key: char
+    /// A key is released
+    | KeyUp of key: string
     /// Down arrow is pressed
     | DownArrow
     /// Up arrow is pressed
@@ -43,6 +45,7 @@ type Event =
 
 let fromLowlevelEvent = function
     | Lowlevel.Key t -> Key t
+    | Lowlevel.KeyUp t -> KeyUp t
     | Lowlevel.DownArrow -> DownArrow
     | Lowlevel.UpArrow -> UpArrow
     | Lowlevel.LeftArrow -> LeftArrow

--- a/canvas.fsi
+++ b/canvas.fsi
@@ -22,6 +22,8 @@ type Size = float*float
 type Event =
     /// A key with at letter is pressed
     | Key of key: char
+    /// A key is release
+    | KeyUp of key: string
     /// Down arrow is pressed
     | DownArrow
     /// Up arrow is pressed

--- a/lowlevel.fs
+++ b/lowlevel.fs
@@ -231,6 +231,7 @@ let drawToAnimatedGif width heigth (frameDelay:int) (repeatCount:int) (filePath:
 
 type Event =
     | Key of char
+    | KeyUp of string
     | DownArrow
     | UpArrow
     | LeftArrow
@@ -255,6 +256,7 @@ let classifyEvent userClassify ev =
         | SDL.KeyDown kevent when kevent.keysym.sym = SDL.SDLK_LEFT -> React LeftArrow
         | SDL.KeyDown kevent when kevent.keysym.sym = SDL.SDLK_RIGHT -> React RightArrow
         | SDL.KeyDown kevent when kevent.keysym.sym = SDL.SDLK_RETURN -> React Return
+        | SDL.KeyUp kevent -> SDL.stringFromKeyboard kevent |> KeyUp |> React
         | SDL.MouseButtonDown mouseButtonEvent ->
             (mouseButtonEvent.x,mouseButtonEvent.y) |> MouseButtonDown |> React
         | SDL.MouseButtonUp mouseButtonEvent ->


### PR DESCRIPTION
Using the Canvas module there is currently no way to detect when several keys is used at the same time, since KeyPress events only fire for the latest pressed button. An example of the consequences of this is that in a game-like app you are unable to move and rotate (and/or fire) at the same time.

Adding a KeyUp event that fires whenever a key is released would allow for state management, in effect allowing for the use of several keys at any given time, but without increasing the complexity of the current toolset.

Old behavior:

Key 'q'
Key 'w'
Key 'e'
Key 'r'
LeftArrow
DownArrow
RightArrow
UpArrow

New behavior:

Key 'q'
KeyUp "Q"
Key 'w'
KeyUp "W"
Key 'e'
KeyUp "E"
Key 'r'
KeyUp "R"
LeftArrow
KeyUp "Left"
DownArrow
KeyUp "Down"
RightArrow
KeyUp "Right"
UpArrow
KeyUp "Up"
